### PR TITLE
Add refines command

### DIFF
--- a/refines
+++ b/refines
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Runs FDR's `refines` command inside of a Docker container.
+
+# Create FDR's config directory in the host.  The first time you run this
+# command, you'll be prompted for licensing information, and you'll have to
+# obtain a license file from the FDR maintainers.  (This all happens
+# automatically based on your answers to a prompt.)  We store the license on the
+# host so that you don't have to reacquire your license every time you run this
+# command.
+mkdir -p "$HOME"/.config/fdr
+
+# Run the refines command in a container.  We share two directories inside the
+# container: the FDR config directory, and $PWD.  Both are exposed at the same
+# locations inside the container, so that whatever filenames you pass in on the
+# command line can be passed as-is to FDR.
+docker run --rm \
+    -e HOME="$HOME" \
+    -u $(id -u):$(id -g) \
+    -v "$HOME"/.config/fdr:"$HOME"/.config/fdr \
+    -v "$PWD":"$PWD" \
+    -w "$PWD" \
+    dcreager/fdr \
+    /usr/bin/refines \
+    "$@"


### PR DESCRIPTION
This is a shell wrapper around FDR's [refines command](http://www.cs.ox.ac.uk/projects/fdr/manual/command_line.html).  We run it inside of a Docker container (created via `make`) so that you don't have to worry about how to install FDR on your host OS.  We expose `$PWD` inside the container so that you can pass in whichever CSP scripts you want to analyze.  We also expose FDR's per-user config directory, so that we can save your FDR license file on the host, allowing you to reuse it however many times you spin up an FDR container.
